### PR TITLE
Fixed a strange but when paths contain commas

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var parse = function(torrent) {
 	result.name = name;
 
 	result.files = (torrent.info.files || [torrent.info]).map(function(file, i, files) {
-		var parts = [].concat(file.name || name, file.path || []).map(toString);
+		var parts = [].concat(file.name || name, file.path || []).map(function(p) { return p.toString() });
 		return {
 			path: path.join.apply(null, [path.sep].concat(parts)).slice(1),
 			name: parts.pop(),


### PR DESCRIPTION
Node.js v0.8.22: when using .map(toString), an item from the array that contained a comma would be stringified only before the comma.
E.g. "example, example example" would become "example".

This, wierdly, fixes it.
