### PR TITLE
Allow to pass options to request

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,13 @@ module.exports = function(url, callback) {
 	};
 
 	if (Buffer.isBuffer(url)) return ondata(null, url);
-	if (/^https?:/.test(url)) return request(url, {encoding:null}, onresponse);
+
+	var urlIsObject = (typeof url === 'object' && !(url instanceof String));
+	if (urlIsObject || /^https?:/.test(url)) {
+		var options = urlIsObject? url: {url:url};
+		options.encoding = null;
+		return request(options, onresponse);
+	}
 
 	fs.readFile(url, ondata);
 };


### PR DESCRIPTION
Some private tracker require the client to authenticate through HTTP or to use a token in the request headers. This patch allow a user to give an object used by `request`.
