### PR TITLE
Use parse-torrent by feross

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # read-torrent
 
-read and parse a torrent from a resource
+Read and parse a torrent from a resource
 
 	npm install read-torrent
 
-# usage
+## Usage
 
 ``` js
 var readTorrent = require('read-torrent');
@@ -18,37 +18,72 @@ readTorrent('mydir/file.torrent', function(err, torrent) {
 });
 ```
 
-The torrent result looks like this
+The torrent result looks like this:
 
 ``` js
 {
-	name: 'torrent name',
-	created: new Date(...),
-	announce: [
-		// list of annouce urls
-	],
-	infoHash: 'infoHash as a hex string',
-	files: [{
-		name: 'name of file',
-		path: 'suggested file path',
-		offset: absoluteOffset,
-		length: lengthOfFile
-	}],
-	pieceLength: lengthOfAPiece,
-	pieces: [
-		// list of sha1 hex strings
-	]
+  infoHash: 'd2474e86c95b19b8bcfdb92bc12c9d44667cfa36',
+  name: 'Leaves of Grass by Walt Whitman.epub',
+  private: false,
+  created: new Date('Thu Aug 01 2013 06:27:46 GMT-0700 (PDT)'),
+  announce: [
+    'http://tracker.thepiratebay.org/announce',
+    'udp://tracker.openbittorrent.com:80',
+    'udp://tracker.ccc.de:80',
+    'udp://tracker.publicbt.com:80',
+    'udp://fr33domtracker.h33t.com:3310/announce'
+  ],
+  files: [
+    {
+      path: 'Leaves of Grass by Walt Whitman.epub',
+      name: 'Leaves of Grass by Walt Whitman.epub',
+      length: 362017,
+      offset: 0
+    }
+  ],
+  length: 362017,
+  pieceLength: 16384,
+  lastPieceLength: 1569,
+  pieces: [
+    '1f9c3f59beec079715ec53324bde8569e4a0b4eb',
+    'ec42307d4ce5557b5d3964c5ef55d354cf4a6ecc',
+    '7bf1bcaf79d11fa5e0be06593c8faafc0c2ba2cf',
+    '76d71c5b01526b23007f9e9929beafc5151e6511',
+    '0931a1b44c21bf1e68b9138f90495e690dbc55f5',
+    '72e4c2944cbacf26e6b3ae8a7229d88aafa05f61',
+    'eaae6abf3f07cb6db9677cc6aded4dd3985e4586',
+    '27567fa7639f065f71b18954304aca6366729e0b',
+    '4773d77ae80caa96a524804dfe4b9bd3deaef999',
+    'c9dd51027467519d5eb2561ae2cc01467de5f643',
+    '0a60bcba24797692efa8770d23df0a830d91cb35',
+    'b3407a88baa0590dc8c9aa6a120f274367dcd867',
+    'e88e8338c572a06e3c801b29f519df532b3e76f6',
+    '70cf6aee53107f3d39378483f69cf80fa568b1ea',
+    'c53b506159e988d8bc16922d125d77d803d652c3',
+    'ca3070c16eed9172ab506d20e522ea3f1ab674b3',
+    'f923d76fe8f44ff32e372c3b376564c6fb5f0dbe',
+    '52164f03629fd1322636babb2c014b7dae582da4',
+    '1363965261e6ce12b43701f0a8c9ed1520a70eba',
+    '004400a267765f6d3dd5c7beb5bd3c75f3df2a54',
+    '560a61801147fa4ec7cf568e703acb04e5610a4d',
+    '56dcc242d03293e9446cf5e457d8eb3d9588fd90',
+    'c698de9b0dad92980906c026d8c1408fa08fe4ec'
+  ]
 }
 ```
 
-# command-line interface
+## Command-line interface
 
-there is also a command-line interface available if you install it with `-g`
+There is also a command-line interface available if you install it with `-g`
 
 	npm install -g read-torrent
 
-this installs a program called `read-torrent` that you simply pass a torrent file or url
+This installs a program called `read-torrent` that you simply pass a torrent file or url
 
 	read-torrent http://my-server.com/file.torrent
 
-this will print all meta info of the torrent file to the terminal
+This will print all meta info of the torrent file to the terminal
+
+## Comments
+
+Thanks to https://github.com/feross for https://github.com/feross/parse-torrent

--- a/cli.js
+++ b/cli.js
@@ -21,18 +21,28 @@ if (!process.argv[2]) {
 }
 
 readTorrent(process.argv[2], function(err, torrent) {
-	console.log('info hash: '+torrent.infoHash);
-	console.log('created:   '+formatDate(torrent.created));
-	console.log('pieces:    '+torrent.pieces.length + ' x '+formatSize(torrent.pieceLength));
 
-	console.log('name:      '+torrent.name);
-	console.log('files:     '+torrent.files[0].name+ ' ('+formatSize(torrent.files[0].length)+')');
-	for (var i = 1; i < torrent.files.length; i++) {
-		console.log('           '+torrent.files[i].name+ ' ('+formatSize(torrent.files[i].length)+')');
+	if (!!err) {
+		console.error(err);
+		process.exit(1);
 	}
 
-	console.log('trackers:  '+torrent.announce[0]);
-	for (var i = 1; i < torrent.announce.length; i++) {
-		console.log('           '+torrent.announce[i]);
+	if (torrent.infoHash) console.log('info hash: '+torrent.infoHash);
+	if (torrent.created)  console.log('created:   '+formatDate(torrent.created));
+	if (torrent.pieces)   console.log('pieces:    '+torrent.pieces.length + ' x '+formatSize(torrent.pieceLength));
+	if (torrent.name)     console.log('name:      '+torrent.name);
+	
+	if (torrent.files) {
+		console.log('files:     '+torrent.files[0].name+ ' ('+formatSize(torrent.files[0].length)+')');
+		for (var i = 1; i < torrent.files.length; i++) {
+			console.log('           '+torrent.files[i].name+ ' ('+formatSize(torrent.files[i].length)+')');
+		}
+	}
+
+	if (torrent.announce) {
+		console.log('trackers:  '+torrent.announce[0]);
+		for (var i = 1; i < torrent.announce.length; i++) {
+			console.log('           '+torrent.announce[i]);
+		}
 	}
 });

--- a/index.js
+++ b/index.js
@@ -1,88 +1,32 @@
-var crypto = require('crypto');
-var bncode = require('bncode');
 var request = require('request');
-var path = require('path');
 var fs = require('fs');
 var zlib = require('zlib');
+var parseTorrent = require('parse-torrent');
 
-var sumLength = function(sum, file) {
-	return sum + file.length;
-};
+module.exports = function readTorrent (url, callback) {
+	// Ensure true async callback, no matter what.
+	var asyncCallback = function(err, data) {
+		process.nextTick(function() { callback(err, data); });
+	};
 
-var splitPieces = function(buffer) {
-	var pieces = [];
-	for (var i = 0; i < buffer.length; i += 20) {
-		pieces.push(buffer.slice(i, i + 20).toString('hex'));
-	}
-	return pieces;
-};
-
-var parse = function(torrent) {
-	torrent = bncode.decode(torrent);
-
-	var result = {};
-	var name = torrent.info.name.toString();
-	var pieceLength = torrent.info['piece length'];
-	var files = (torrent.info.files || [torrent.info]);
-
-	result.created = new Date(torrent['creation date'] * 1000);
-	result.announce = (torrent['announce-list'] || [torrent.announce]).map(function(obj) {
-		return obj.toString().split(',')[0];
-	});
-	result.infoHash = crypto.createHash('sha1').update(bncode.encode(torrent.info)).digest('hex');
-	result.private = !!torrent.info.private;
-	result.name = name;
-	result.length = files.reduce(sumLength, 0);
-
-	result.files = files.map(function(file, i) {
-		var parts = [].concat(file.name || name, file.path || []).map(function(p) {
-			return p.toString();
-		});
-
-		var result = {};
-
-		result.path = path.join.apply(null, [path.sep].concat(parts)).slice(1);
-		result.name = parts.pop();
-		result.length = file.length;
-		result.offset = files.slice(0, i).reduce(sumLength, 0);
-		result.end = result.offset + result.length - 1;
-		result.offsetPiece = (result.offset / pieceLength) | 0;
-		result.endPiece = (result.end / pieceLength) | 0;
-
-		return result;
-	});
-
-	var lastFile = result.files[result.files.length-1];
-
-	result.pieceLength = pieceLength;
-	result.pieceRemainder = (result.length % pieceLength) || pieceLength;
-	result.pieces = splitPieces(torrent.info.pieces);
-
-	return result;
-};
-
-module.exports = function(url, callback) {
-	var ondata = function(err, data) {
-		if (err) return callback(err);
-		try {
-			data = parse(data);
-		} catch (err) {
-			return callback(err);
+	var onData = function (err, data) {
+		if (err) return asyncCallback(err);
+		try { 
+			data = parseTorrent(data); 
+		} catch (e) { 
+			return asyncCallback(e);
 		}
-
-		callback(null, data);
+		asyncCallback(null, data);
 	};
 
-	var onresponse = function(err, response) {
-		if (err) return callback(err);
-		if (response.statusCode >= 400) return callback(new Error('bad status: '+response.statusCode));
-		if (response.headers['content-encoding'] === 'gzip') return zlib.gunzip(response.body, ondata);
-
-		ondata(null, response.body);
+	var onResponse = function (err, response) {
+		if (err) return asyncCallback(err);
+		if (response.statusCode >= 400) return asyncCallback(new Error('Bad Response: '+response.statusCode));
+		if (response.headers['content-encoding'] === 'gzip') return zlib.gunzip(response.body, onData);
+		onData(null, response.body);
 	};
 
-	if (Buffer.isBuffer(url)) return ondata(null, url);
-	if (/^https?:/.test(url)) return request(url, {encoding:null}, onresponse);
-
-	fs.readFile(url, ondata);
+	if (Buffer.isBuffer(url)) return onData(null, url);
+	if (/^https?:/.test(url)) return request(url, {encoding:null}, onResponse);
+	fs.readFile(url, onData);
 };

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "read-torrent",
   "version": "0.2.0",
-  "description": "read and parse a torrent from a resource",
+  "description": "Read and parse a torrent from a resource.",
   "repository": "git://github.com/mafintosh/read-torrent.git",
   "dependencies": {
-    "bncode": "~0.2.3",
-    "request": "~2.16.2"
+    "request": "~2.16.2",
+    "parse-torrent": "~1.0.0"
   },
   "bin": {
     "read-torrent":"./cli.js"


### PR DESCRIPTION
There's no point on implementing multiple versions of a torrent parser.
Let's use feross' and maintain only one. His version is based on this project's original algorithm, but he improved it to make it work in browsers too, which is fine, and removed a few dependencies.

Commit changes:
- Parse with `parse-torrent`
- Ensure a true asynchronous callback with `process.nextTick`
- Updated README.
- Added error checking in cli.js
