### PR TITLE
bump request dependency to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "magnet-uri": "~2.0.0",
     "parse-torrent": "^4.0.0",
-    "request": "~2.16.2",
+    "request": "^2.83.0",
     "xtend": "^4.0.0"
   },
   "bin": {


### PR DESCRIPTION
request@2.16.2 is using an outdated version of `qs`.